### PR TITLE
Chore: Add error handler middleware

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,24 @@
 import express from 'express';
+import errorHandler from './errorHandler';
 
 const app = express();
+const PORT = process.env.port || 3000;
+const { genericError } = errorHandler;
 
 app.get('/', (req, res) => {
   res.send('This is my first Express server');
 });
 
-app.listen(process.env.port || 3000);
+app.use('/', (err, req, res, next) => {
+  // if response has already started streaming and error occurs, pass it to Express
+  // default error handler - it will close the connection and fail the request.
+  if (res.headersSent) {
+    next(err);
+  } else {
+    genericError(err, req, res);
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Listening on port ${PORT}`);
+});

--- a/src/errorHandler.js
+++ b/src/errorHandler.js
@@ -1,0 +1,13 @@
+/** function handling all non-specific errors. It creates an error with a generic message and passes
+ * passes it to Express error handler using next() function (to handle asynchronous errors, which
+ * wouldn't happen if the function just threw the error).
+ * @param {Error} err is expected to be an Error object
+ * @param {Object} req is expected to be an an object with info about the request
+ * @param {Object} res is expected to be an an object with info about the response
+ * @returns {null}.
+ */
+function genericError(err, req, res) {
+  res.sendStatus(500);
+}
+
+export default { genericError };


### PR DESCRIPTION
#### What does this PR do?
It adds error handler middleware

#### How should this be manually tested?
In `app.js`, replace `res.send('This is my first Express server');` with `throw new Error('some error;);`. Expected result: server should respond with code `500` and without any data. `Internal server error` shoud display on the website.

#### Any background context you want to provide?
I decided to create a separate file `errorHandler.js` instead of writing the error handling function in `app.js`, because if in the future we need to implement more robust error handling system, it will be easier to manage

#### Questions:
In this part of code:
```
else {
  genericError(err, req, res);
}
```
when I add some logging and try to use `next()` function:
```
else {
  console.log('Custom error handler runs...');
  genericError(err, req, res);
  next();
  console.log('I expect this part to not execute');
}
```
both `console.log()` calls are executed. Why is that? My understanding is that `next()`  stops the execution of currently executed middleware and moves to the next middleware. Is that not the case? Does it wait until all synchronous code in the middleware is executed and only then moves to the next one, even if `next()` is called before some synchronous code?